### PR TITLE
xp assertions: explicity expect NumPy scalars

### DIFF
--- a/scipy/_lib/tests/test__util.py
+++ b/scipy/_lib/tests/test__util.py
@@ -445,7 +445,7 @@ class TestLazywhere:
             ref2 = ref2.reshape(result_shape)
             ref3 = ref3.reshape(result_shape)
 
-        xp_assert_close(res1, ref1, rtol=2e-16, check_0d=False)
-        xp_assert_equal(res2, ref2, check_0d=False)
+        xp_assert_close(res1, ref1, rtol=2e-16)
+        xp_assert_equal(res2, ref2)
         if not is_array_api_strict(xp):
-            xp_assert_equal(res3, ref3, check_0d=False)
+            xp_assert_equal(res3, ref3)

--- a/scipy/_lib/tests/test_array_api.py
+++ b/scipy/_lib/tests/test_array_api.py
@@ -120,29 +120,32 @@ class TestArrayAPI:
 
         # identity always passes
         xp_assert_equal(xp.float64(0), xp.float64(0))
-        xp_assert_equal(xp.array(0.), xp.array(0.))
+        xp_assert_equal(xp.asarray(0.), xp.asarray(0.))
         xp_assert_equal(xp.float64(0), xp.float64(0), check_0d=False)
-        xp_assert_equal(xp.array(0.), xp.array(0.), check_0d=False)
+        xp_assert_equal(xp.asarray(0.), xp.asarray(0.), check_0d=False)
 
         # Check default convention: 0d-arrays are distinguished from scalars
         message = "Array-ness does not match:.*"
         with pytest.raises(AssertionError, match=message):
-            xp_assert_equal(xp.array(0.), xp.float64(0))
+            xp_assert_equal(xp.asarray(0.), xp.float64(0))
         with pytest.raises(AssertionError, match=message):
-            xp_assert_equal(xp.float64(0), xp.array(0.))
+            xp_assert_equal(xp.float64(0), xp.asarray(0.))
         with pytest.raises(AssertionError, match=message):
-            xp_assert_equal(xp.array(42), xp.int64(42))
+            xp_assert_equal(xp.asarray(42), xp.int64(42))
         with pytest.raises(AssertionError, match=message):
-            xp_assert_equal(xp.int64(42), xp.array(42))
+            xp_assert_equal(xp.int64(42), xp.asarray(42))
 
         # with `check_0d=False`, scalars-vs-0d passes (if values match)
-        xp_assert_equal(xp.array(0.), xp.float64(0), check_0d=False)
-        xp_assert_equal(xp.float64(0), xp.array(0.), check_0d=False)
+        xp_assert_equal(xp.asarray(0.), xp.float64(0), check_0d=False)
+        xp_assert_equal(xp.float64(0), xp.asarray(0.), check_0d=False)
         # also with regular python objects
-        xp_assert_equal(xp.array(0.), 0., check_0d=False)
-        xp_assert_equal(0., xp.array(0.), check_0d=False)
-        xp_assert_equal(xp.array(42), 42, check_0d=False)
-        xp_assert_equal(42, xp.array(42), check_0d=False)
+        xp_assert_equal(xp.asarray(0.), 0., check_0d=False)
+        xp_assert_equal(0., xp.asarray(0.), check_0d=False)
+        xp_assert_equal(xp.asarray(42), 42, check_0d=False)
+        xp_assert_equal(42, xp.asarray(42), check_0d=False)
+
+        # as an alternative to `check_0d=False`, explicitly expect scalar
+        xp_assert_equal(xp.float64(0), xp.asarray(0.)[()])
 
 
     @array_api_compatible
@@ -153,32 +156,32 @@ class TestArrayAPI:
         # identity passes, if first argument is not 0d (or check_0d=True)
         xp_assert_equal_no_0d(xp.float64(0), xp.float64(0))
         xp_assert_equal_no_0d(xp.float64(0), xp.float64(0), check_0d=True)
-        xp_assert_equal_no_0d(xp.array(0.), xp.array(0.), check_0d=True)
+        xp_assert_equal_no_0d(xp.asarray(0.), xp.asarray(0.), check_0d=True)
 
         # by default, 0d values are forbidden as the first argument
         message = "Result is a NumPy 0d-array.*"
         with pytest.raises(AssertionError, match=message):
-            xp_assert_equal_no_0d(xp.array(0.), xp.array(0.))
+            xp_assert_equal_no_0d(xp.asarray(0.), xp.asarray(0.))
         with pytest.raises(AssertionError, match=message):
-            xp_assert_equal_no_0d(xp.array(0.), xp.float64(0))
+            xp_assert_equal_no_0d(xp.asarray(0.), xp.float64(0))
         with pytest.raises(AssertionError, match=message):
-            xp_assert_equal_no_0d(xp.array(42), xp.int64(42))
+            xp_assert_equal_no_0d(xp.asarray(42), xp.int64(42))
 
         # Check default convention: 0d-arrays are NOT distinguished from scalars
-        xp_assert_equal_no_0d(xp.float64(0), xp.array(0.))
-        xp_assert_equal_no_0d(xp.int64(42), xp.array(42))
+        xp_assert_equal_no_0d(xp.float64(0), xp.asarray(0.))
+        xp_assert_equal_no_0d(xp.int64(42), xp.asarray(42))
 
         # opt in to 0d-check remains possible
         message = "Array-ness does not match:.*"
         with pytest.raises(AssertionError, match=message):
-            xp_assert_equal_no_0d(xp.array(0.), xp.float64(0), check_0d=True)
+            xp_assert_equal_no_0d(xp.asarray(0.), xp.float64(0), check_0d=True)
         with pytest.raises(AssertionError, match=message):
-            xp_assert_equal_no_0d(xp.float64(0), xp.array(0.), check_0d=True)
+            xp_assert_equal_no_0d(xp.float64(0), xp.asarray(0.), check_0d=True)
         with pytest.raises(AssertionError, match=message):
-            xp_assert_equal_no_0d(xp.array(42), xp.int64(0), check_0d=True)
+            xp_assert_equal_no_0d(xp.asarray(42), xp.int64(0), check_0d=True)
         with pytest.raises(AssertionError, match=message):
-            xp_assert_equal_no_0d(xp.int64(0), xp.array(42), check_0d=True)
+            xp_assert_equal_no_0d(xp.int64(0), xp.asarray(42), check_0d=True)
 
         # scalars-vs-0d passes (if values match) also with regular python objects
-        xp_assert_equal_no_0d(0., xp.array(0.))
-        xp_assert_equal_no_0d(42, xp.array(42))
+        xp_assert_equal_no_0d(0., xp.asarray(0.))
+        xp_assert_equal_no_0d(42, xp.asarray(42))

--- a/scipy/constants/tests/test_constants.py
+++ b/scipy/constants/tests/test_constants.py
@@ -13,7 +13,7 @@ skip_xp_backends = pytest.mark.skip_xp_backends
 class TestConvertTemperature:
     def test_convert_temperature(self, xp):
         xp_assert_equal(sc.convert_temperature(xp.asarray(32.), 'f', 'Celsius'),
-                        xp.asarray(0.0), check_0d=False)
+                        xp.asarray(0.0)[()])
         xp_assert_equal(sc.convert_temperature(xp.asarray([0., 0.]),
                                                'celsius', 'Kelvin'),
                         xp.asarray([273.15, 273.15]))

--- a/scipy/differentiate/tests/test_differentiate.py
+++ b/scipy/differentiate/tests/test_differentiate.py
@@ -29,7 +29,7 @@ class TestDifferentiate:
         default_dtype = xp.asarray(1.).dtype
         res = differentiate(self.f, xp.asarray(x, dtype=default_dtype))
         ref = xp.asarray(stats.norm().pdf(x), dtype=default_dtype)
-        xp_assert_close(res.df, ref, check_0d=False)
+        xp_assert_close(res.df, ref[()])
         # This would be nice, but doesn't always work out. `error` is an
         # estimate, not a bound.
         if not is_torch(xp):
@@ -365,7 +365,7 @@ class TestDifferentiate:
         if not is_torch(xp):  # torch defaults to float32
             res = differentiate(f, xp.asarray(7), tolerances=dict(rtol=1e-10))
             assert res.success
-            xp_assert_close(res.df, xp.asarray(99*7.**98), check_0d=False)
+            xp_assert_close(res.df, xp.asarray(99*7.**98)[()])
 
         # Test that if success is achieved in the correct number
         # of iterations if function is a polynomial. Ideally, all polynomials
@@ -383,8 +383,7 @@ class TestDifferentiate:
 
             res = differentiate(f, x, maxiter=1, order=max(1, n))
             xp_assert_close(res.df, ref, rtol=1e-15)
-            xp_assert_equal(res.error, xp.asarray(xp.nan, dtype=xp.float64),
-                            check_0d=False)
+            xp_assert_equal(res.error, xp.asarray(xp.nan, dtype=xp.float64)[()])
 
             res = differentiate(f, x, order=max(1, n))
             assert res.success
@@ -396,7 +395,7 @@ class TestDifferentiate:
             return c*x - 1
 
         res = differentiate(f, xp.asarray(2), args=xp.asarray(3))
-        xp_assert_close(res.df, xp.asarray(3.), check_0d=False)
+        xp_assert_close(res.df, xp.asarray(3.)[()])
 
     # no need to run a test on multiple backends if it's xfailed
     @pytest.mark.skip_xp_backends(np_only=True)

--- a/scipy/integrate/tests/test_tanhsinh.py
+++ b/scipy/integrate/tests/test_tanhsinh.py
@@ -225,10 +225,10 @@ class TestTanhSinh:
         ref = xp.asarray(ref, dtype=dtype)
 
         res = _tanhsinh(norm_pdf, *limits)
-        xp_assert_close(res.integral, ref, check_0d=False)
+        xp_assert_close(res.integral, ref[()])
 
         logres = _tanhsinh(norm_logpdf, *limits, log=True)
-        xp_assert_close(xp.exp(logres.integral), ref, check_0d=False, check_dtype=False)
+        xp_assert_close(xp.exp(logres.integral), ref[()], check_dtype=False)
         # Transformation should not make the result complex unnecessarily
         xp_test = array_namespace(*limits)  # we need xp.isdtype
         assert (xp_test.isdtype(logres.integral.dtype, "real floating") if ref > 0
@@ -538,7 +538,7 @@ class TestTanhSinh:
         a, b = xp.asarray(0.), xp.asarray(xp.pi/4)
         res = _tanhsinh(f, a, b)
         ref = math.sqrt(2)/2 + (1-math.sqrt(2)/2)*1j
-        xp_assert_close(res.integral, xp.asarray(ref), check_0d=False)
+        xp_assert_close(res.integral, xp.asarray(ref)[()])
 
         # Infinite limits
         def f(x):
@@ -546,7 +546,7 @@ class TestTanhSinh:
 
         a, b = xp.asarray(xp.inf), xp.asarray(-xp.inf)
         res = _tanhsinh(f, a, b)
-        xp_assert_close(res.integral, xp.asarray(-(1+1j)), check_0d=False)
+        xp_assert_close(res.integral, xp.asarray(-(1+1j))[()])
 
     @pytest.mark.parametrize("maxlevel", range(4))
     def test_minlevel(self, maxlevel, xp):
@@ -681,28 +681,28 @@ class TestTanhSinh:
 
         res = _tanhsinh(f, a, b)
         assert res.success
-        xp_assert_close(res.integral, xp.asarray(0.5), check_0d=False)
+        xp_assert_close(res.integral, xp.asarray(0.5)[()])
 
         # Test levels 0 and 1; error is NaN
         res = _tanhsinh(f, a, b, maxlevel=0)
         assert res.integral > 0
-        xp_assert_equal(res.error, xp.asarray(xp.nan), check_0d=False)
+        xp_assert_equal(res.error, xp.asarray(xp.nan)[()])
         res = _tanhsinh(f, a, b, maxlevel=1)
         assert res.integral > 0
-        xp_assert_equal(res.error, xp.asarray(xp.nan), check_0d=False)
+        xp_assert_equal(res.error, xp.asarray(xp.nan)[()])
 
         # Test equal left and right integration limits
         res = _tanhsinh(f, b, b)
         assert res.success
         assert res.maxlevel == -1
-        xp_assert_close(res.integral, xp.asarray(0.), check_0d=False)
+        xp_assert_close(res.integral, xp.asarray(0.)[()])
 
         # Test scalar `args` (not in tuple)
         def f(x, c):
             return x**c
 
         res = _tanhsinh(f, a, b, args=29)
-        xp_assert_close(res.integral, xp.asarray(1/30), check_0d=False)
+        xp_assert_close(res.integral, xp.asarray(1/30)[()])
 
         # Test NaNs
         a = xp.asarray([xp.nan, 0, 0, 0])
@@ -726,9 +726,9 @@ class TestTanhSinh:
         _pair_cache.h0 = None
         a, b = xp.asarray(0), xp.asarray(1)
         res = _tanhsinh(lambda x: xp.asarray(x*1j), a, b)
-        xp_assert_close(res.integral, xp.asarray(0.5*1j), check_0d=False)
+        xp_assert_close(res.integral, xp.asarray(0.5*1j)[()])
         res = _tanhsinh(lambda x: x, a, b)
-        xp_assert_close(res.integral, xp.asarray(0.5), check_0d=False)
+        xp_assert_close(res.integral, xp.asarray(0.5)[()])
 
         # Test zero-size
         shape = (0, 3)

--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -2599,7 +2599,7 @@ def test_uniform_filter1d_roundoff_errors(xp):
 
     for filter_size in range(3, 10):
         out = ndimage.uniform_filter1d(in_, filter_size)
-        xp_assert_equal(xp.sum(out), xp.asarray(10 - filter_size), check_0d=False)
+        xp_assert_equal(xp.sum(out), xp.asarray(10 - filter_size)[()])
 
 
 def test_footprint_all_zeros(xp):

--- a/scipy/special/tests/test_support_alternative_backends.py
+++ b/scipy/special/tests/test_support_alternative_backends.py
@@ -89,4 +89,5 @@ def test_support_alternative_backends(xp, f_name_n_args, dtype, shapes):
     ref = xp.asarray(f(*args_np), dtype=dtype_xp)
 
     eps = np.finfo(dtype_np).eps
-    xp_assert_close(res, ref, atol=10*eps, check_0d=False)
+    ref = ref[()] if ref.ndim == 0 else ref
+    xp_assert_close(res, ref, atol=10*eps)

--- a/scipy/stats/tests/test_resampling.py
+++ b/scipy/stats/tests/test_resampling.py
@@ -945,8 +945,8 @@ class TestMonteCarloHypothesisTest:
 
         res = monte_carlo_test(x, rvs, statistic, alternative=alternative)
 
-        xp_assert_close(res.statistic, xp.asarray(ref.statistic))
-        xp_assert_close(res.pvalue, xp.asarray(ref.pvalue), atol=self.atol)
+        xp_assert_close(res.statistic, xp.asarray(ref.statistic)[()])
+        xp_assert_close(res.pvalue, xp.asarray(ref.pvalue)[()], atol=self.atol)
 
 
     # Tests below involve statistics that are not yet array-API compatible.


### PR DESCRIPTION
I'm pretty sure this is preferable since it allows us to keep the 0d check enabled. x-ref https://github.com/scipy/scipy/pull/21026